### PR TITLE
Cleanup function outputs

### DIFF
--- a/R/ebscoBWR.R
+++ b/R/ebscoBWR.R
@@ -445,27 +445,12 @@ ebscoBWR.f <- function(path, rmDuplicates = TRUE, firstAbstractOnly=TRUE, csv=FA
   # Reorder variables
   DF <- select(DF, articleID, attributes, record)
 
-  rm(blank, path, sub.1, sub.2, sub.3, sub.4, sub.5, variables.to.keep)
-  #_______________________________________________________________________________
-  #                        8. OUTPUT
-  #-------------------------------------------------------------------------------
-  #
-  # This final section places a datafile in the global environment, which is
-  # called ebscoBWR.df.  If csv is specified as TRUE in the ebscoBWR function call,
-  # a csv file is written to the user's current working directory.  A few messages
-  # are written to the user's screen, providing a warning message and a few
-  # quality checks to ensure the number of articles matches the number of sources.
-  #_______________________________________________________________________________
+  # write to CSV if necessary
+  if (csv) {
+    write.csv(DF, "ebscoBWR.csv")
+    message("The `ebscoBWR.csv` file can be found in your working directory: ", getwd())
+    return(invisible(DF))
+  }
 
-  ebscoBWR.df <<- DF
-
-  rm(DF)
-  if(csv == TRUE){write.csv(ebscoBWR.df, "ebscoBWR.csv")}
-
-  cat(
-    "****************************************************\n          Wrangling is complete\n****************************************************")
-
-  if(csv == TRUE){cat(
-    "\nThe `ebscoBWR.csv` file can be found in your working directory:\n", getwd())}
+  DF
 }
-

--- a/R/proquestBWR.R
+++ b/R/proquestBWR.R
@@ -196,27 +196,12 @@ proQuestBWR.f <- function(path, rmDuplicates=TRUE, csv = FALSE){
     rownames(DF) <- NULL
     DF <- select(DF, articleID, attributes, record)
 
-    #_______________________________________________________________________________
-    #                        6. OUTPUT
-    #-------------------------------------------------------------------------------
-    #
-    # This final section places a datafile in the global environment, which is
-    # called bwr.df.  If csv is specified as TRUE in the ebscoBWR function call,
-    # a csv file is written to the user's current working directory.  A few messages
-    # are written to the user's screen, providing a warning message and a few
-    # quality checks to ensure the number of articles matches the number of sources.
-    #_______________________________________________________________________________
+  # write to CSV if necessary
+  if (csv) {
+    write.csv(DF, "proQuestBWR.csv")
+    message("The `proQuestBWR.csv` file can be found in your working directory: ", getwd())
+    return(invisible(DF))
+  }
 
-    proQuestBWR.df <<- DF
-    if(csv == TRUE){write.csv(proQuestBWR.df, file="proQuestBWR.csv")}
-
-    cat(
-        "****************************************************
-              Wrangling is complete
-****************************************************")
-
-    if(csv == TRUE){cat(
-        "\nThe `proQuestBWR.csv` file can be found in your working directory:\n", getwd())}
-
+  DF
 }
-


### PR DESCRIPTION
Edited the end of both functions to return the `DF` object rather than writing it to the calling environment. When printing to a CSV, a small `message` (rather than `cat`) is returned giving the location of the file, and `DF` is returned _invisibly_, meaning it can still be assigned like

```
DF <- proQuestBWR.f(<file path>, csv=TRUE)
```

but  `DF` will not be printed otherwise. Also removed the "wrangling is complete" block messages.

Closes #2.
